### PR TITLE
fix issue #1: doesn't work for images with width > 256

### DIFF
--- a/cv/fft/fft.js
+++ b/cv/fft/fft.js
@@ -153,7 +153,12 @@
     // initialize the array (supports TypedArray)
     _initArray : function() {
       if(typeof Uint8Array !== 'undefined') {
-        _bitrev = new Uint8Array(_n);
+				if(_n<=256)
+					_bitrev = new Uint8Array(_n);
+				else if(_n<=65536)
+					_bitrev = new Uint16Array(_n);
+				else
+					_bitrev = new Uint32Array(_n);
       } else {
         _bitrev = [];
       }


### PR DESCRIPTION
Like said in the issue, a Uint8array for _bitrev was just enough to deal with 256 entries so it failed with larger images.